### PR TITLE
Automatically assign issues to DRI responsible

### DIFF
--- a/.github/workflows/assignIssueDRI.yml
+++ b/.github/workflows/assignIssueDRI.yml
@@ -1,0 +1,70 @@
+name: Assign issue to DRI responsible
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+    assignIssue:
+        name: Assign issue to DRI responsible
+        runs-on: ubuntu-latest
+        if: github.repository == 'microsoft/vscode-tools-for-ai'
+        steps:
+            - uses: actions/checkout@v3
+            - name: Created internally
+              id: internal
+              env:
+                  ISSUE_OWNER: ${{ github.event.issue.user.login }}
+              run: |
+                  echo ::set-output name=result::$(node -p -e "['greazer', 'sevillal', 'shsuman', 'tbombach', 'yaoleo34'].filter(item => process.env.ISSUE_OWNER.toLowerCase() === item.toLowerCase()).length > 0 ? 1 : 0")
+              shell: bash
+            - name: Should we proceed
+              id: proceed
+              env:
+                  ISSUE_ASSIGNEES: ${{toJson(github.event.issue.assignees)}}
+                  ISSUE_IS_INTERNAL: ${{steps.internal.outputs.result}}
+              run: |
+                  echo ::set-output name=result::$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 ? 1 : 0")
+              shell: bash
+            - name: Calculate week number
+              if: steps.proceed.outputs.result == 1
+              id: week
+              run: |
+                echo ::set-output name=week::$(node .github/workflows/week.js)
+              shell: bash            
+            - name: Print week number
+              if: steps.proceed.outputs.result == 1
+              run: |
+                echo ${{steps.week.outputs.week}}
+              shell: bash
+            - name: Get DRI responsible
+              if: steps.proceed.outputs.result == 1
+              id: dri
+              env:
+                DRI_RESPONSIBLE_DEFAULT: ${{vars.DRI_RESPONSIBLE_DEFAULT}}
+                DRI_OWNERS: ${{vars.DRI_OWNERS}}
+              run: |
+                echo ::set-output name=result::$(node .github/workflows/dri.js)
+              shell: bash
+            - name: Print DRI responsible
+              if: steps.proceed.outputs.result == 1
+              run: |
+                echo ${{steps.dri.outputs.result}}
+              shell: bash
+            - name: Assign issue to DRI responsible
+              if: steps.proceed.outputs.result == 1
+              env:
+                DRI_RESPONSIBLE: ${{steps.dri.outputs.result}}
+              uses: actions/github-script@v6.4.1
+              with:
+                github-token: ${{secrets.GITHUB_TOKEN}}
+                script: |
+                  github.rest.issues.addAssignees({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    assignees: ['${{ env.DRI_RESPONSIBLE }}']
+                  })

--- a/.github/workflows/dri.js
+++ b/.github/workflows/dri.js
@@ -1,0 +1,14 @@
+var getWeekNumber = require('./getWeekNumber.js');
+
+function getDRIResponsible(driOwnersString) {
+    if (!driOwnersString) {
+        return process.env.DRI_RESPONSIBLE_DEFAULT || 'tbombach';
+    }
+    const owners = driOwnersString.split(' ');
+    const countOfOwners = owners.length;
+    const weekNumber = getWeekNumber(new Date());
+    const responsibleIndex = weekNumber % countOfOwners;
+    return owners[responsibleIndex];
+}
+
+console.log(getDRIResponsible(process.env.DRI_OWNERS));

--- a/.github/workflows/getWeekNumber.js
+++ b/.github/workflows/getWeekNumber.js
@@ -1,0 +1,10 @@
+function getWeekNumber(d) {
+    // Copy date so don't modify original
+    d = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+    // Get first day of year
+    var yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    // Calculate full weeks
+    return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+}
+
+module.exports = getWeekNumber;

--- a/.github/workflows/week.js
+++ b/.github/workflows/week.js
@@ -1,0 +1,3 @@
+var getWeekNumber = require('./getWeekNumber.js');
+
+console.log(getWeekNumber(new Date()));


### PR DESCRIPTION
- Automatically assign issue to DRI owner
- Needs the following Repository Variables:
  - DRI_OWNERS = tbombach sevillal shsuman
  - DRI_RESPONSIBLE_DEFAULT = sevillal

Fixes: https://github.com/microsoft/vscode-tools-for-ai/issues/2114